### PR TITLE
fix(webhooks): register body parser on URI-versioned routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,14 @@ export class AppModule {}
 
 - Accepts **`application/json`**, **`application/cloudevents+json`**, and **`application/cloudevents-batch+json`** (Intuit’s CloudEvents types use the latter two).
 - Sets **`req.rawBody`** in the parser `verify` callback so `QuickBooksWebhooksGuard` can HMAC the same bytes Intuit signed.
+
+If the app uses URI versioning (`/v1/quickbooks/webhook`), pass the same version in webhook options so the parser is registered on the versioned route:
+
+```ts
+QuickBooksModule.forRoot({
+    webhooks: {
+        version: "1",
+        webhookHandler: MyWebhookHandler
+    }
+})
+```

--- a/lib/modules/webhooks/webhooks.module.spec.ts
+++ b/lib/modules/webhooks/webhooks.module.spec.ts
@@ -1,4 +1,4 @@
-import { Injectable, Module } from "@nestjs/common";
+import { Injectable, Module, VersioningType } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import { createHmac, randomBytes } from "node:crypto";
 import supertest from "supertest";
@@ -121,6 +121,47 @@ describe("QuickbooksWebhooksModule", () => {
             await supertest(app.getHttpServer())
                 .post("/quickbooks/webhook")
                 .set("Content-Type", "application/json")
+                .set("intuit-signature", signRaw(raw))
+                .send(body)
+                .expect(204);
+
+            expect(handler.handleEvent).toHaveBeenCalledTimes(1);
+            expect(handler.handleEvent).toHaveBeenCalledWith(payload);
+        });
+    });
+
+    describe("HTTP + body parser with URI versioning", () => {
+        let app: import("@nestjs/common").INestApplication;
+        let handler: IntegrationTestWebhookHandler;
+
+        beforeAll(async () => {
+            const testingModule = await Test.createTestingModule({
+                imports: [
+                    QuickbooksWebhooksModule.forRoot({
+                        imports: [WebhooksTestDepsModule],
+                        version: "1"
+                    })
+                ]
+            }).compile();
+
+            app = testingModule.createNestApplication({ bodyParser: false });
+            app.enableVersioning({ type: VersioningType.URI, defaultVersion: "1" });
+            handler = testingModule.get(QuickbooksWebhookHandlerService) as IntegrationTestWebhookHandler;
+            await app.init();
+        });
+
+        afterAll(async () => {
+            await app.close();
+        });
+
+        it("returns 204 for POST /v1/quickbooks/webhook with a valid signature", async () => {
+            const payload: QuickbooksWebhookPayload = [sampleEvent()];
+            const body = JSON.stringify(payload);
+            const raw = Buffer.from(body, "utf8");
+
+            await supertest(app.getHttpServer())
+                .post("/v1/quickbooks/webhook")
+                .set("Content-Type", "application/cloudevents-batch+json")
                 .set("intuit-signature", signRaw(raw))
                 .send(body)
                 .expect(204);

--- a/lib/modules/webhooks/webhooks.module.ts
+++ b/lib/modules/webhooks/webhooks.module.ts
@@ -1,5 +1,6 @@
-import { DynamicModule, ForwardReference, Module, NestModule, RequestMethod, Type } from "@nestjs/common";
-import type { RawBodyRequest, MiddlewareConsumer } from "@nestjs/common";
+import { DynamicModule, ForwardReference, Inject, Module, NestModule, Optional, RequestMethod, Type } from "@nestjs/common";
+import type { RawBodyRequest, MiddlewareConsumer, Provider } from "@nestjs/common";
+import { VersionValue } from "@nestjs/common/interfaces";
 import { json } from "body-parser";
 import { QuickBooksWebhooksController } from "./controllers/webhooks.controller";
 import { QuickbooksWebhookHandlerService } from "./services/webhook-handler.service";
@@ -7,18 +8,24 @@ import { QuickbooksWebhookHandlerService } from "./services/webhook-handler.serv
 export interface CustomQuickbooksWebhooksOptions {
     imports?: (Type | DynamicModule | Promise<DynamicModule> | ForwardReference)[];
     webhookHandler: Type<QuickbooksWebhookHandlerService>;
+    version?: VersionValue;
 }
 
 export interface ImportsQuickbooksWebhooksOptions {
     imports: [Type | DynamicModule | Promise<DynamicModule> | ForwardReference];
+    version?: VersionValue;
 }
 
 export type QuickbooksWebhooksOptions = CustomQuickbooksWebhooksOptions | ImportsQuickbooksWebhooksOptions;
+
+const QUICKBOOKS_WEBHOOKS_VERSION = Symbol("QUICKBOOKS_WEBHOOKS_VERSION");
 
 @Module({
     controllers: [QuickBooksWebhooksController]
 })
 export class QuickbooksWebhooksModule implements NestModule {
+    constructor(@Inject(QUICKBOOKS_WEBHOOKS_VERSION) private readonly version?: VersionValue) {}
+
     public configure(consumer: MiddlewareConsumer): void {
         const middleware = json({
             type: ["application/json", "application/cloudevents+json", "application/cloudevents-batch+json"],
@@ -29,20 +36,22 @@ export class QuickbooksWebhooksModule implements NestModule {
 
         consumer.apply(middleware).forRoutes({
             path: "quickbooks/webhook",
-            method: RequestMethod.POST
+            method: RequestMethod.POST,
+            version: this.version
         });
     }
 
     public static forRoot(options: QuickbooksWebhooksOptions): DynamicModule {
+        const providers: Provider[] = [{ provide: QUICKBOOKS_WEBHOOKS_VERSION, useValue: options.version }];
+
+        if ("webhookHandler" in options) {
+            providers.push({ provide: QuickbooksWebhookHandlerService, useClass: options.webhookHandler });
+        }
+
         return {
             module: QuickbooksWebhooksModule,
             imports: options?.imports ? [...options.imports] : [],
-            providers: "webhookHandler" in options ? [
-                {
-                    provide: QuickbooksWebhookHandlerService,
-                    useClass: options.webhookHandler
-                }
-            ] : []
+            providers
         };
     }
 }


### PR DESCRIPTION
## Summary
- Nest URI versioning mounts the webhook at `/v1/quickbooks/webhook`, but the CloudEvents body parser was hardcoded to `POST /quickbooks/webhook`, so `req.rawBody` never got set and signature checks failed.
- `QuickbooksWebhooksOptions` now accepts `version`; when set, the parser is registered on the same versioned route as the controller.
- Documented the option in the README and added an integration test for `POST /v1/quickbooks/webhook`.

